### PR TITLE
Fix hero buttons not clickable due to gradient overlay

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,7 +18,7 @@ export default function Home() {
     <div className="min-h-screen">
       {/* Hero Section - Dark */}
       <section className="relative overflow-hidden bg-slate-900">
-        <div className="absolute inset-0 bg-gradient-to-b from-orange-500/10 via-transparent to-transparent" />
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-orange-500/10 via-transparent to-transparent" />
         <div className="mx-auto max-w-6xl px-4 py-20 sm:px-6 lg:px-8 lg:py-28">
           <div className="text-center">
             <h1 className="mx-auto max-w-4xl text-4xl font-semibold tracking-tight text-white sm:text-5xl lg:text-6xl">


### PR DESCRIPTION
Add pointer-events-none to the absolute positioned gradient overlay
in the hero section so clicks pass through to the underlying buttons.